### PR TITLE
Make recovery words copyable

### DIFF
--- a/WalletWasabi.Fluent/Views/AddWallet/Create/RecoveryWordsView.axaml
+++ b/WalletWasabi.Fluent/Views/AddWallet/Create/RecoveryWordsView.axaml
@@ -25,6 +25,16 @@
       </Grid.RowDefinitions>
 
       <Panel Grid.Row="2" VerticalAlignment="Center" HorizontalAlignment="Center">
+        <Panel.ContextMenu>
+          <ContextMenu>
+            <MenuItem Header="Copy to clipboard"
+                      Command="{Binding CopyToClipboardCommand}">
+              <MenuItem.Icon>
+                <PathIcon Data="{StaticResource clipboard_text_regular}" />
+              </MenuItem.Icon>
+            </MenuItem>
+          </ContextMenu>
+        </Panel.ContextMenu>
         <ItemsControl Items="{Binding MnemonicWords}">
           <ItemsControl.Styles>
             <Style Selector="TextBlock">


### PR DESCRIPTION
 - Enables right-click context menu in the recovery words screen with the "Copy to Clipboard" option.
 - Clears the recovery words from clipboard if they're still there after 30 seconds.